### PR TITLE
[Link T-2953] Take ownership of release_watch deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,4 +149,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.10-slim
+
+WORKDIR /src
+COPY ./requirements.txt .
+COPY ./release_bot/ .
+
+RUN pip install -r requirements.txt
+
+ENV PYTHONUNBUFFERED=1
+
+CMD ["python3", "bot.py"]

--- a/release_bot/bot.py
+++ b/release_bot/bot.py
@@ -13,10 +13,10 @@ from dotenv import load_dotenv
 import humanize
 import yaml
 
-from .github_latest_release import get_latest_release, GithubReleaseInfo
+from github_latest_release import get_latest_release, GithubReleaseInfo
 
 ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
-DEFAULT_REPOS_FILE = os.path.join(ROOT, "repos.yml")
+DEFAULT_REPOS_FILE = "./repos.yml"
 
 discord_client = discord.Client()
 

--- a/release_bot/repos.yml
+++ b/release_bot/repos.yml
@@ -2,91 +2,76 @@
 algorand:
   channels:
     - 931305730080915526
-    - 930945459902640151
   critical: true
   repo: https://github.com/algorand/go-algorand
 arweave:
   channels:
     - 931305730080915526
-    - 930945459902640151
   critical: false
   repo: https://github.com/ArweaveTeam/arweave
 avalanche:
   channels:
     - 931305730080915526
-    - 930945459902640151
   critical: true
   repo: https://github.com/ava-labs/avalanchego
 binance:
   channels:
     - 931305730080915526
-    - 930945459902640151
   critical: true
   repo: https://github.com/binance-exchange/binance-api-node
 bitcoin:
   channels:
     - 931305730080915526
-    - 930945459902640151
   critical: false
   repo: https://github.com/bitcoin/bitcoin
 ethereum:
   channels:
     - 931305730080915526
-    - 930945459902640151
   critical: true
   repo: https://github.com/ethereum/go-ethereum
 erigon:
   channels:
     - 931305730080915526
-    - 930945459902640151
   critical: true
   repo: https://github.com/ledgerwatch/erigon
 evmos:
   channels:
     - 931305730080915526
-    - 930945459902640151
   critical: true
   repo: https://github.com/tharsis/evmos
 fuse:
   channels:
     - 931305730080915526
-    - 930945459902640151
   critical: true
   repo: https://github.com/fuseio/fuse-network
 harmony:
   channels:
     - 931305730080915526
-    - 930945459902640151
   critical: true
   repo: https://github.com/harmony-one/harmony
 iotex:
   channels:
     - 931305730080915526
-    - 930945459902640151
   critical: true
   repo: https://github.com/iotexproject/iotex-core
 pocket:
   channels:
     - 931305730080915526
-    - 930945459902640151
   critical: true
   repo: https://github.com/pokt-network/pocket-core/releases
 polygon:
   channels:
     - 931305730080915526
-    - 930945459902640151
   critical: true
   repo: https://github.com/maticnetwork/bor
 solana:
   channels:
     - 931305730080915526
-    - 930945459902640151
   critical: true
   repo: https://github.com/solana-labs/solana
 test:
   channels:
     - 931305730080915526
-    - 930945459902640151
   critical: true
   repo: https://github.com/pokt-foundation/node-watch-test
 


### PR DESCRIPTION
Changes were made to bot.py to allow it to run from CLI and in a docker container.

This is just the initial PR to get the Dockerfile up there, will be looking to create the github actions to automatically build and push the image.